### PR TITLE
add a dot to floating-point-matching regex

### DIFF
--- a/lib/task.py
+++ b/lib/task.py
@@ -120,7 +120,7 @@ class NagiosTask(Task):
         perf_data = raw_perf.split(" ")
         for item in perf_data:
             key, val = item.split(';')[0].split('=')
-            attributes[attrprefix + key] = float(re.match('([0-9]+)', val).group(1))
+            attributes[attrprefix + key] = float(re.match('([0-9.]+)', val).group(1))
 
         return attributes
 


### PR DESCRIPTION
With this extra little dot, floating-point-valued performance data from
Nagios will be correctly submitted to Riemann
