### PR TITLE
Halt execution in JSONTask on JSON parse errors

### DIFF
--- a/lib/task.py
+++ b/lib/task.py
@@ -259,6 +259,7 @@ class JSONTask(SubProcessTask):
                 results = json.loads(stdout)
             except Exception as e:
                 log.error("Failed to parse JSON. '%s':\n%s" % (self.name, str(e)))
+                return
 
             for result in results:
                 for field in ['service', 'state', 'description', 'metric']:


### PR DESCRIPTION
before execution would continue which result in an undefined
variable (results) getting accessed which caused a further exception.
