### PR TITLE
Change status code description from 'warn' to 'warning'.

### DIFF
--- a/lib/task.py
+++ b/lib/task.py
@@ -191,7 +191,7 @@ class NagiosTask(SubProcessTask):
     exitcodes = {
      -127: 'timeout',
         0: 'ok',
-        1: 'warn',
+        1: 'warning',
         2: 'critical',
         3: 'unknown'
     }


### PR DESCRIPTION
For compatibility with alerta dashboard (http://alerta.io) this change is needed as status 'warn' it treats as 'unknown'.
http://nagios.sourceforge.net/docs/3_0/pluginapi.html also describes it as 'WARNING', not 'WARN'.