### PR TITLE
Don't prefix attributes with task_ for JSONTask

### DIFF
--- a/lib/task.py
+++ b/lib/task.py
@@ -31,6 +31,9 @@ DEFAULT_MULTIPLIER = 5
 
 SEED_TIMING = 0.5
 
+RIEMANN_CORE_FIELDS = ['host', 'service', 'state', 'time',
+                       'description', 'tags', 'metric', 'ttl']
+
 # Numeric matcher for parsing Nagios performance data
 # create class constant compiled regex, to prevent
 # unecessarily recompiling this regex string.
@@ -255,6 +258,12 @@ class JSONTask(SubProcessTask):
     def __init__(self, config):
         SubProcessTask.__init__(self, config)
 
+    def clean_attribute_name(self, attrname):
+        if attrname.lower() in RIEMANN_CORE_FIELDS:
+            return self.attrprefix + attrname
+
+        return attrname
+
     def join(self):
         try:
             stdout, stderr, returncode = SubProcessTask.join(self)
@@ -278,7 +287,8 @@ class JSONTask(SubProcessTask):
                 event.attributes = self.attributes
 
                 if "attributes" in result:
-                    event.attributes.update(dict((self.attrprefix + name, result["attributes"][name]) for name in result["attributes"]))
+                    attributes = result["attributes"]
+                    event.attributes.update(dict((self.clean_attribute_name(key), attributes[key]) for key in attributes))
 
                 event.service = result['service']
                 event.state = result['state']


### PR DESCRIPTION
We may not need to prefix attributes for JSONTask, since we generally control the output. This is in contrast to supporting arbitrary pre-existing nagios checks for NagiosTask.