### PR TITLE
Task: Improve error messaging in timed-out events.

### DIFF
--- a/lib/task.py
+++ b/lib/task.py
@@ -197,7 +197,17 @@ class SubProcessTask(Task):
                 self.process.kill()
                 self.process.wait()
                 log.debug("Subprocess killed for task '%s'" % (self.name))
-                return '', '', -127
+
+                stdout = "Sumd task timeout of %ds reached, so the task subprocess was killed before completing" % (timeout)
+                if self.stdout is not None:
+                    stdout = self.stdout + "\n^^ End of Output ^^\n" + stdout
+
+                if self.stderr is not None:
+                    stderr = self.stderr
+                else:
+                    stderr = ''
+
+                return stdout, stderr, -127
 
             return self.stdout, self.stderr, self.process.returncode
         except Exception as e:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from distutils.core import setup
 
-version = "0.5.2"
+version = "0.5.3"
 
 setup(name="riemann-sumd",
       version=version,


### PR DESCRIPTION
When task scripts fail to complete during execution, we force the stdout and stderr values to be empty. This misses an opportunity to clearly state what happened.