### PR TITLE
Task: use process groups to ensure proper task kills

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from distutils.core import setup
 
-version = "0.5.4"
+version = "0.6.0"
 
 setup(name="riemann-sumd",
       version=version,


### PR DESCRIPTION
We have a monitor in production that (for reasons) spawns a child process that sometimes exceed the task-kill TTL. Killing the monitor leaves it's child process, which causes those child processes to pile up over time.

This should ensure that the whole tree is grouped and subsequently killed with SIGKILL.

A SO post explaining this technique is available here: https://stackoverflow.com/a/4791612