### PR TITLE
Task: capture stderr, log when communicate completes

### DIFF
--- a/lib/task.py
+++ b/lib/task.py
@@ -180,8 +180,9 @@ class SubProcessTask(Task):
 
     def proc(self):
         try:
-            self.process = subprocess.Popen(self.command, stdout=subprocess.PIPE, shell=self.use_shell, preexec_fn=os.setsid)
+            self.process = subprocess.Popen(self.command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=self.use_shell, preexec_fn=os.setsid)
             self.stdout, self.stderr = self.process.communicate()
+            log.debug("process.communicate() completed for task '%s' (stdout: '%s' returncode: %d)" % (self.name, self.stdout, self.process.returncode))
         except Exception as e:
             log.exception("Exception running command '%s'\n%s" % (self.arg, str(e)))
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from distutils.core import setup
 
-version = "0.6.0"
+version = "0.6.1"
 
 setup(name="riemann-sumd",
       version=version,


### PR DESCRIPTION
This PR has two tweaks:

1) Fixes a missing stderr=subprocess.PIPE (see: https://docs.python.org/2/library/subprocess.html#subprocess.Popen.communicate)

2) Adds debug logging to identify if `process.communicate()` has completed successfully.