### PR TITLE
Support systemd

### DIFF
--- a/init/ubuntu/sumd.service
+++ b/init/ubuntu/sumd.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=riemann-sumd - a Python agent for scheduling event generating processes and sending the results to Riemann
+
+[Service]
+WorkingDirectory=/opt/sumd
+ExecStart=/opt/sumd/bin/sumd
+
+[Install]
+WantedBy=multi-user.target

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [install]
 prefix = /opt/sumd
 install-lib = %(prefix)s/lib
+install-scripts = %(prefix)s/bin
 
 [bdist_rpm]
 requires = python-yaml

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,23 @@
 #!/usr/bin/env python
 from distutils.core import setup
+import platform
 
-version = "0.7.1"
+version = "0.7.2"
+
+distro = platform.dist()[0]
+distro_major_version = platform.dist()[1].split('.')[0]
+
+data_files=[('/etc/sumd', ['examples/etc/sumd/sumd.conf']),
+            ('/etc/sumd/tasks.d', ['examples/etc/sumd/tasks.d/simple.task.example']),
+            ('/etc/sumd/tags.d', ['examples/etc/sumd/tags.d/simple.tag.example'])]
+
+if distro == 'Ubuntu':
+  if distro_major_version >= 16:
+    data_files.append(('/usr/lib/systemd/system',
+                       ['init/ubuntu/sumd.service']))
+  else:
+    data_files.append(('/etc/init',
+                       ['init/ubuntu/sumd.conf']))
 
 setup(name="riemann-sumd",
       version=version,
@@ -11,10 +27,7 @@ setup(name="riemann-sumd",
       url="https://github.com/bmhatfield/riemann-sumd",
       package_dir={'': 'lib'},
       py_modules=['event', 'loader', 'scheduler', 'sender', 'task', 'runner'],
-      data_files=[('/etc/init/', ["init/ubuntu/sumd.conf"]),
-                  ('/etc/sumd', ['examples/etc/sumd/sumd.conf']),
-                  ('/etc/sumd/tasks.d', ['examples/etc/sumd/tasks.d/simple.task.example']),
-                  ('/etc/sumd/tags.d', ['examples/etc/sumd/tags.d/simple.tag.example'])],
+      data_files=data_files,
       scripts=["bin/sumd"],
       install_requires=[
             "pyyaml",


### PR DESCRIPTION
Add systemd configuration.

Also support backwards compatability when compiling on Xenial+, which will install the sumd binary to `/usr/bin` unless `install-scripts` is specified in `setup.cfg`.